### PR TITLE
Disable script injection for HtmlWebpackPlugin

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -17,7 +17,8 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: './src/index.html'
+      template: './src/index.html',
+      inject: false
     }),
     new CopyPlugin({
       patterns: [{


### PR DESCRIPTION
Without specifying the `inject: false` option, all of the generated scripts (`popup.js`, `contentScript.js` and `background.js`) are injected into the HTML template. This means that all messaging subscriptions will be duplicated which may result in unexpected behavior due to multiple listeners receiving the same events.

This won't cause any problems with the `popup.js` script as it's manually specified in the template `index.html` file.